### PR TITLE
Fixed potential package bundle clash on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "com.reactlibrary"
+        group = "com.sudoplz.rninappupdates"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.sudoplz.rninappupdates">
 
 </manifest>

--- a/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesModule.java
+++ b/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.sudoplz.rninappupdates;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -6,6 +6,7 @@ import android.content.IntentSender;
 import android.util.Log;
 
 import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -48,11 +49,12 @@ public class SpInAppUpdatesModule extends ReactContextBaseJavaModule implements 
     public SpInAppUpdatesModule(ReactApplicationContext reactContext) {
         super(reactContext);
         // Creates instance of the manager.
-        appUpdateManager = AppUpdateManagerFactory.create(this.getReactApplicationContext());
+        appUpdateManager = AppUpdateManagerFactory.create(reactContext);
         appUpdateManager.registerListener(this);
         reactContext.addActivityEventListener(this);
     }
 
+    @NonNull
     @Override
     public String getName() {
         return "SpInAppUpdates";
@@ -165,10 +167,10 @@ public class SpInAppUpdatesModule extends ReactContextBaseJavaModule implements 
 
 
     @MainThread
-    private boolean emitToJS(String key, String value) {
+    private void emitToJS(String key, String value) {
         ReactContext reactContext = this.getReactApplicationContext();
         if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
-            return false;
+            return;
         }
 
         try {
@@ -177,9 +179,6 @@ public class SpInAppUpdatesModule extends ReactContextBaseJavaModule implements 
             ).emit(key, value);
         } catch (Exception e) {
             Log.wtf("InAppUpdates_EMITTER", "Error sending Event: sp_in_app_updates_" + key, e);
-            return false;
         }
-
-        return true;
     }
 }

--- a/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesPackage.java
+++ b/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesPackage.java
@@ -1,6 +1,7 @@
-package com.reactlibrary;
+package com.sudoplz.rninappupdates;
 
-import java.util.Arrays;
+import androidx.annotation.NonNull;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -8,16 +9,17 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
 
 public class SpInAppUpdatesPackage implements ReactPackage {
+    @NonNull
     @Override
-    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new SpInAppUpdatesModule(reactContext));
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new SpInAppUpdatesModule(reactContext));
     }
 
+    @NonNull
     @Override
-    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/github_account/sp-react-native-in-app-updates.git",
-    "baseUrl": "https://github.com/github_account/sp-react-native-in-app-updates"
+    "url": "git+https://github.com/SudoPlz/sp-react-native-in-app-updates.git",
+    "baseUrl": "https://github.com/SudoPlz/sp-react-native-in-app-updates"
   },
   "keywords": [
     "react-native"
@@ -33,7 +33,7 @@
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {
-    "react": "^16.9.0",
-    "react-native": "^0.61.5"
+    "react": "16.13.1",
+    "react-native": "0.63.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {
-    "react": "16.13.1",
-    "react-native": "0.63.1"
+    "react": "^16.9.0",
+    "react-native": "^0.61.5"
   }
 }


### PR DESCRIPTION
This PR fixes a potential bundle clash with other packages since it used the default package bundle name instead of a unique one.

It also applies Android Studio's linter recommended fixes.