### PR TITLE
Added status progress and miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Because to this day I'm not aware of any react-native libraries that use play co
 
 ##### `checkNeedsUpdate(checkOptions: CheckOptions) : CheckResult`
 
+Checks if there are any updates available.
+
 Where: 
 `CheckOptions`
 
@@ -52,6 +54,8 @@ and `CheckResult`:
 
 ##### `startUpdate(checkOptions: UpdateOptions) : Promise`
 
+Shows pop-up asking user if they want to update, giving them the option to download said update.
+
 Where: 
 `UpdateOptions `
 
@@ -64,6 +68,39 @@ Where:
 |  buttonCancelText (iOS only) | (optional) String  |  The text of the cancelation button on the alert prompt (default: `Cancel`)|
 |  forceUpgrade (iOS only) | (optional) Boolean  |  If set to true the user won't be able to cancel the upgrade (default: false)|
 
+##### `installUpdate() : void` (Android only)
+
+Installs a downloaded update.
+
+##### `addStatusUpdateListener(callback: (status: UpdateStatus) : void) : void` (Android only)
+
+Adds a listener for tracking the current status of the update download.
+
+Where: `UpdateStatus`
+
+| Option | Type  | Description  |
+|---|---|---|
+|  status | int | One of `DownloadStatusEnum` |
+|  bytesDownloaded | int | How many bytes were already downloaded |
+|  totalBytesToDownload | int | The total amount of bytes in the update |
+
+Where: `DownloadStatusEnum`
+
+`SpInAppUpdates.UPDATE_STATUS.AVAILABLE` |
+`SpInAppUpdates.UPDATE_STATUS.DEVELOPER_TRIGGERED` |
+`SpInAppUpdates.UPDATE_STATUS.UNAVAILABLE` |
+`SpInAppUpdates.UPDATE_STATUS.UNKNOWN` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_CANCELED` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_DOWNLOADED` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_DOWNLOADING` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_FAILED` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_INSTALLED` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_INSTALLING` |
+`SpInAppUpdates.UPDATE_STATUS.UPDATE_PENDING`
+
+##### `removeStatusUpdateListener(callback: (status: UpdateStatus) : void): void`
+
+Removes an existing download status listener.
 
 ##Example:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sp-react-native-in-app-updates
 
+![In app update example](https://user-images.githubusercontent.com/8539174/88419625-6db0ef00-cddd-11ea-814e-389db852368b.gif)
+
 ## Getting started
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Where: `DownloadStatusEnum`
 `SpInAppUpdates.UPDATE_STATUS.UPDATE_INSTALLING` |
 `SpInAppUpdates.UPDATE_STATUS.UPDATE_PENDING`
 
-##### `removeStatusUpdateListener(callback: (status: UpdateStatus) : void): void`
+##### `removeStatusUpdateListener(callback: (status: UpdateStatus) : void): void` (Android only)
 
 Removes an existing download status listener.
 

--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -12,6 +12,13 @@ const UPDATE_STATUS = {
     UNAVAILABLE: SpInAppUpdates.UPDATE_NOT_AVAILABLE,
     UNKNOWN: SpInAppUpdates.UPDATE_UNKNOWN,
     DEVELOPER_TRIGGERED: SpInAppUpdates.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS,
+    UPDATE_CANCELED: SpInAppUpdates.UPDATE_CANCELED,
+    UPDATE_DOWNLOADED: SpInAppUpdates.UPDATE_DOWNLOADED,
+    UPDATE_DOWNLOADING: SpInAppUpdates.UPDATE_DOWNLOADING,
+    UPDATE_FAILED: SpInAppUpdates.UPDATE_FAILED,
+    UPDATE_INSTALLED: SpInAppUpdates.UPDATE_INSTALLED,
+    UPDATE_INSTALLING: SpInAppUpdates.UPDATE_INSTALLING,
+    UPDATE_PENDING: SpInAppUpdates.UPDATE_PENDING,
 };
 const UPDATE_TYPE = {
     IMMEDIATE: SpInAppUpdates.APP_UPDATE_IMMEDIATE,
@@ -26,10 +33,10 @@ export class SpInAppUpdatesModule {
         this.eventEmitter = new NativeEventEmitter(SpInAppUpdates);
         this.eventEmitter.addListener(SpInAppUpdates.IN_APP_UPDATE_STATUS_KEY, this.onIncomingNativeStatusUpdate);
         this.eventEmitter.addListener(SpInAppUpdates.IN_APP_UPDATE_RESULT_KEY, this.onIncomingNativeResult);
-        
+
     }
 
-    onIncomingNativeResult(event) {
+    onIncomingNativeResult = (event) => {
         if (this.resultListeners && this.resultListeners.length > 0) {
             for (const aListener of this.resultListeners) {
                 aListener(event);
@@ -37,10 +44,18 @@ export class SpInAppUpdatesModule {
         }
     }
 
-    onIncomingNativeStatusUpdate(event) {
+    onIncomingNativeStatusUpdate = (event) => {
+        let {bytesDownloaded, totalBytesToDownload} = event;
+        // This data comes from Java as a string, since React's WriteableMap doesn't support `long` type values.
+        bytesDownloaded = parseInt(bytesDownloaded, 10);
+        totalBytesToDownload = parseInt(totalBytesToDownload, 10);
         if (this.statusUpdateListeners && this.statusUpdateListeners.length > 0) {
             for (const aListener of this.statusUpdateListeners) {
-                aListener(event);
+                aListener({
+                    ...event,
+                    bytesDownloaded,
+                    totalBytesToDownload,
+                });
             }
         }
     }
@@ -83,6 +98,7 @@ export class SpInAppUpdatesModule {
         const {
             curVersion,
             toSemverConverter,
+            customVersionComparator,
         } = checkOptions;
         if (!curVersion) {
             this.throwError('You have to include at least the curVersion to the options passed in checkNeedsUpdate', 'checkNeedsUpdate');
@@ -148,6 +164,10 @@ export class SpInAppUpdatesModule {
             .catch(err => {
                 this.throwError(err, 'startUpdate');
             });
+    }
+
+    installUpdate() {
+        SpInAppUpdates.installUpdate();
     }
 
     toString() {

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -4,12 +4,20 @@ import { compareVersions } from './utils';
 
 export class SpInAppUpdatesModule {
     constructor() {
-        this.name = 'sp-react-native-in-app-updates';    
+        this.name = 'sp-react-native-in-app-updates';
     }
 
     throwError(err, scope) {
         throw new Error(`${this.name} ${`${scope} ` || ''}error: ${err}`)
     }
+
+    addStatusUpdateListener() {}
+
+    removeStatusUpdateListener() {}
+
+    addIntentSelectionListener() {}
+
+    removeIntentSelectionListener() {}
 
     checkNeedsUpdate(checkOptions = {}) {
         const {
@@ -63,6 +71,8 @@ export class SpInAppUpdatesModule {
     startUpdate(updateOptions) {
         return Promise.resolve(Siren.promptUser(updateOptions));
     }
+
+    installUpdate() {}
 
     toString() {
         return this.name;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,16 @@
     "name": "Ioannis Kokkinidis",
     "email": "sudoplz@gmail.com"
   },
+  "maintainers": [
+    {
+      "name": "Ioannis Kokkinidis",
+      "email": "sudoplz@gmail.com"
+    },
+    {
+      "name": "Gustavo Parreira",
+      "email": "gustavotcparreira@gmail.com"
+    }
+  ],
   "license": "MIT",
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",


### PR DESCRIPTION
This PR does a few things:
- Added empty stubs to the iOS JS implementation to match the Android one, to avoid having to check the platform each time.
- Added installUpdate function to start the native install implementation for Flexible updates.
- Status listener returning bytes downloaded and total bytes to download.
- Fixed listeners not working due to a mismatched `this` context.

Here's a video with a rough implementation of these changes:

![Example Flow](https://user-images.githubusercontent.com/8539174/88419625-6db0ef00-cddd-11ea-814e-389db852368b.gif)

If you want me to write documentation for these let me know.

Also let me know if you'd be interested in making me a maintainer of this package as well.
