### PR TITLE
Sending update priority to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and `CheckResult`:
 
 | Result | Type  | Description  |
 |---|---|---|
-| shouldUpdate  | Boolean | Wether there's a newer version on the store or not  |
+|  shouldUpdate  | Boolean | Wether there's a newer version on the store or not  |
 |  storeVersion | String  |  The latest app/play store version we're aware of |
 |  other | Object  | Other info returned from the store (differs on Android/iOS) |
 
@@ -86,7 +86,7 @@ Where: `UpdateStatus`
 |  bytesDownloaded | int | How many bytes were already downloaded |
 |  totalBytesToDownload | int | The total amount of bytes in the update |
 
-Where: `DownloadStatusEnum`
+and: `DownloadStatusEnum`
 
 `SpInAppUpdates.UPDATE_STATUS.AVAILABLE` |
 `SpInAppUpdates.UPDATE_STATUS.DEVELOPER_TRIGGERED` |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Removes an existing download status listener.
 import SpInAppUpdates from 'sp-react-native-in-app-updates';
 
 const inAppUpdates = new SpInAppUpdates();
+const HIGH_PRIORITY_UPDATE = 5; // Arbitrary, depends on how you handle priority in the Play Console
 
 inAppUpdates.checkNeedsUpdate({
   curVersion: '4.8.8',
@@ -124,8 +125,12 @@ inAppUpdates.checkNeedsUpdate({
   })
 }).then(result => {
   if (result.shouldUpdate) {
+      const updateType = result.other.updatePriority >= HIGH_PRIORITY_UPDATE
+          ? SpInAppUpdates.UPDATE_TYPE.IMMEDIATE
+          : SpInAppUpdates.UPDATE_TYPE.FLEXIBLE;
+
 	  inAppUpdates.startUpdate({
-	    updateType: SpInAppUpdates.UPDATE_TYPE.FLEXIBLE // android only, on iOS the user will be promped to go to your app store page
+	    updateType, // android only, on iOS the user will be promped to go to your app store page
 	  })
   }
 })

--- a/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesModule.java
+++ b/android/src/main/java/com/sudoplz/rninappupdates/SpInAppUpdatesModule.java
@@ -104,6 +104,7 @@ public class SpInAppUpdatesModule extends ReactContextBaseJavaModule implements 
             map.putInt("updateAvailability", availability);
             map.putBoolean("isImmediateUpdateAllowed", appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE));
             map.putBoolean("isFlexibleUpdateAllowed", appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE));
+            map.putInt("updatePriority", appUpdateInfo.updatePriority());
             Integer clientVersionStaleness = appUpdateInfo.clientVersionStalenessDays();
             if (clientVersionStaleness != null) {
                 map.putInt("dayStaleness", clientVersionStaleness.intValue());

--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -106,14 +106,8 @@ export class SpInAppUpdatesModule {
         return SpInAppUpdates.checkNeedsUpdate()
             .then(inAppUpdateInfo => {
                 const info = inAppUpdateInfo || {};
-                const {
-                    // isFlexibleUpdateAllowed,
-                    // isImmediateUpdateAllowed,
-                    // packageName,
-                    // totalBytes,
-                    updateAvailability,
-                    versionCode,
-                } = info;
+                const { updateAvailability, versionCode } = info;
+
                 if (updateAvailability === UPDATE_STATUS.AVAILABLE) {
                     let newAppV = versionCode;
                     if (toSemverConverter) {


### PR DESCRIPTION
This PR exposes the update priority to JS. This should bring the package's capabilities to native API feature parity on Android.

You'll get `updatePriority` in the resolve of `checkNeedsUpdate` inside `other.updatePriority`.