### PR TITLE
feat(ios): adds country and other's missing options of Siren's performCheck method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,25 @@ and `NeedsUpdateResponse`:
 
 <br>
 
-#### `startUpdate(checkOptions: StartUpdateOptions) : Promise`
+#### `startUpdate(updateOptions: StartUpdateOptions) : Promise`
 
 Shows pop-up asking user if they want to update, giving them the option to download said update.
+
 
 Where:
 `StartUpdateOptions `
 
-| Option | Type  | Description  |
-|---|---|---|
-| updateType (Android ONLY) | (required on Android) [IAUUpdateKind](https://github.com/SudoPlz/sp-react-native-in-app-updates/blob/master/src/types.ts#L78) | Either `IAUUpdateKind.FLEXIBLE` or `IAUUpdateKind.IMMEDIATE`. This uses play-core below the hood, read more [here](https://developer.android.com/guide/playcore/in-app-updates) about the two modes. |
-|  title (iOS only) | (optional) String  |  The title of the alert prompt when there's a new version. (default: `Update Available`) |
-|  message (iOS only) | (optional) String  |  The content of the alert prompt when there's a new version (default: `There is an updated version available on the App Store. Would you like to upgrade?`)|
-|  buttonUpgradeText (iOS only) | (optional) String  |  The text of the confirmation button on the alert prompt (default: `Upgrade `)|
-|  buttonCancelText (iOS only) | (optional) String  |  The text of the cancelation button on the alert prompt (default: `Cancel`)|
-|  forceUpgrade (iOS only) | (optional) Boolean  |  If set to true the user won't be able to cancel the upgrade (default: false)|
+| Option                            | Type                                                                                                                          | Description                                                                                                                                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| updateType (Android ONLY)         | (required on Android) [IAUUpdateKind](https://github.com/SudoPlz/sp-react-native-in-app-updates/blob/master/src/types.ts#L78) | Either `IAUUpdateKind.FLEXIBLE` or `IAUUpdateKind.IMMEDIATE`. This uses play-core below the hood, read more [here](https://developer.android.com/guide/playcore/in-app-updates) about the two modes.                        |
+| title (iOS only)                  | (optional) String                                                                                                             | The title of the alert prompt when there's a new version. (default: `Update Available`)                                                                                                                                     |
+| message (iOS only)                | (optional) String                                                                                                             | The content of the alert prompt when there's a new version (default: `There is an updated version available on the App Store. Would you like to upgrade?`)                                                                  |
+| buttonUpgradeText (iOS only)      | (optional) String                                                                                                             | The text of the confirmation button on the alert prompt (default: `Upgrade `)                                                                                                                                               |
+| buttonCancelText (iOS only)       | (optional) String                                                                                                             | The text of the cancelation button on the alert prompt (default: `Cancel`)                                                                                                                                                  |
+| forceUpgrade (iOS only)           | (optional) Boolean                                                                                                            | If set to true the user won't be able to cancel the upgrade (default: `false`)                                                                                                                                              |
+| bundleId (iOS only)               | (optional) String                                                                                                             | The id that identifies the app (ex: com.apple.mobilesafari). If undefined, it will be retrieved with react-native-device-info. (default: `undefined`)                                                                       |
+| country (iOS only)                | (optional) String                                                                                                             | If set, it will filter by country code while requesting an update, The value should be [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (default: `undefined`) |
+| versionSpecificOptions (iOS only) | (optional) Array\<IosStartUpdateOptionWithLocalVersion>                                                                       | An array of IosStartUpdateOptionWithLocalVersion that specify rules dynamically based on what version the device is currently running. (default: `undefined`)                                                               |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ inAppUpdates.checkNeedsUpdate({ curVersion: '0.0.8' }).then((result) => {
   }
 });
 ```
+### Usage with app updates for specific country (iOS only)
+```javascript
+//                              👇🏻 (optional)
+inAppUpdates.checkNeedsUpdate({ country: 'it' }).then(result => {
+  if (result.shouldUpdate) {
+    const updateOptions: StartUpdateOptions = Platform.select({
+      ios: {
+        title: 'Update available',
+        message: "There is a new version of the app available on the App Store, do you want to update it?",
+        buttonUpgradeText: 'Update',
+        buttonCancelText: 'Cancel',
+        country: 'it', // 👈🏻 the country code for the specific version to lookup for (optional)
+      },
+      android: {
+        updateType: IAUUpdateKind.IMMEDIATE,
+      },
+    });
+    inAppUpdates.startUpdate(updateOptions);
+  }
+});
+```
 <br>
 <br>
 

--- a/src/InAppUpdates.ios.ts
+++ b/src/InAppUpdates.ios.ts
@@ -89,7 +89,14 @@ export default class InAppUpdates extends InAppUpdatesBase {
   }
 
   startUpdate(updateOptions: IosStartUpdateOptions): Promise<void> {
-    return Promise.resolve(Siren.promptUser(updateOptions));
+    return Promise.resolve(
+      Siren.promptUser(
+        updateOptions,
+        updateOptions?.versionSpecificOptions,
+        updateOptions?.bundleId,
+        updateOptions?.country
+      )
+    );
   }
 
   installUpdate = noop;

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,13 +156,23 @@ export type NeedsUpdateResponse =
   | IosNeedsUpdateResponse
   | AndroidNeedsUpdateResponse;
 
-export type IosStartUpdateOptions = {
+type IosStartUpdateOption = {
   title?: string;
   message?: string;
   buttonUpgradeText?: string;
   buttonCancelText?: string;
   forceUpgrade?: boolean;
   updateType?: never;
+  bundleId?: string;
+  country?: string;
+};
+
+type IosStartUpdateOptionWithLocalVersion = IosStartUpdateOption & {
+  localVersion: string;
+};
+
+export type IosStartUpdateOptions = IosStartUpdateOption & {
+  versionSpecificOptions?: Array<IosStartUpdateOptionWithLocalVersion>;
 };
 
 export type StartUpdateOptions =


### PR DESCRIPTION
Hello.
This package uses react-native-siren's performCheck function to check from the iTunes search API for an available update. This is done through the checkNeedsUpdate and startUpdate methods.

After bringing the country code filter function to react-native-siren, I saw that this functionality has been implemented and the dependency has been increased. But currently only checkNeedsUpdate benefits from the function, the startUpdate method has not been updated accordingly.
Note that without this fix on startUpdate the only country filter on checkNeedsUpdate is useless. In the readme's example the method invocation to startUpdate will trigger a new lookup request to iTunes without the country code, the app won't be found and the update prompt never shown. Obviously this is true for the iOS apps available only for selected countries.

This PR provides the necessary changes to take advantage of the country parameter and other optional parameters allowed by react-native-siren's promptUser function, such as versionSpecificOptions.
I also updated the types and the README.md with the description of the new parameters and a usage example.


Referenced issue: #55  and #64 

