### PR TITLE
fix: NativeEventEmitter warnings since ReactNative 0.65

### DIFF
--- a/android/src/main/java/com/sudoplz/rninappupdates/SpReactNativeInAppUpdatesModule.java
+++ b/android/src/main/java/com/sudoplz/rninappupdates/SpReactNativeInAppUpdatesModule.java
@@ -162,6 +162,16 @@ public class SpReactNativeInAppUpdatesModule extends ReactContextBaseJavaModule 
         appUpdateManager.completeUpdate();
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(double count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
 
     @Override
     public void onStateUpdate(InstallState state) {


### PR DESCRIPTION
fix: NativeEventEmitter warnings since ReactNative 0.65

<img width="342" alt="Screen Shot 2022-02-27 at 19 17 28" src="https://user-images.githubusercontent.com/4987931/155885193-cff5b128-079b-4065-bcc9-2982464d2958.png">

closes #48 