### PR TITLE
Fix Android build when targeting API 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_CORE_APP_UPDATE_VERSION = "2.0.1"
+def DEFAULT_CORE_APP_UPDATE_VERSION = "2.1.0"
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback


### PR DESCRIPTION
Play In-App Updates Library release 2.1.0 version fixes Android build when targeting API 34

https://developer.android.com/reference/com/google/android/play/core/release-notes-in_app_updates
_"Added support for the upcoming Android 14 release. Apps targeting Android 14 and above must upgrade to this version."_

